### PR TITLE
Fix typo, convert list to numpy array, update docs and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pip install numpy pyvista scipy scikit-learn
 5. Once the second axis is selected and confirmed, the mesh will be aligned according to these two axes.
 
 6. Press the `s` key to save the aligned mesh. It will be saved as `transformed_mesh.stl` in the same folder.
+7. Use the `r` key to reset the current selection or `b` to remove the last picked point.
 
 ## Screenshot
 

--- a/align.py
+++ b/align.py
@@ -7,7 +7,7 @@ import tkinter as tk
 from tkinter import filedialog
 
 # Settings
-secound_align_repeatments = 10  # Anzahl der Wiederholungen für die zweite Achse
+second_align_repetitions = 10  # Anzahl der Wiederholungen für die zweite Achse
 
 # Globale Variablen
 picked_points = []
@@ -179,7 +179,7 @@ def align_and_transform(plotter):
 
     # Wende die erste Rotation an und berechne die neue Normale der zweiten Ebene
     rotated_second_points = rotation1.apply(
-        plane_points['second'] - centers['first']) + centers['first']
+        np.array(plane_points['second']) - centers['first']) + centers['first']
     pca_second_rotated = PCA(n_components=3).fit(rotated_second_points)
     normal_second_rotated = pca_second_rotated.components_[-1]
 
@@ -271,7 +271,7 @@ def confirm_axis_selection(plotter, axis):
     elif current_axis_selection == 'second' and axes_confirmed['first'] != axis:
         axes_confirmed['second'] = axis
         # Optionale Ausrichtung für die zweite Achse
-        for _ in range(secound_align_repeatments):
+        for _ in range(second_align_repetitions):
             align_second_axis(plotter)
             align_first_axis(plotter)
 
@@ -341,30 +341,36 @@ def select_mesh_file():
     return file_path
 
 
-# Auswahl der Mesh-Datei
-filename = select_mesh_file()
-if filename:
-    mesh = pv.read(filename)
-else:
-    print("No file selected. The program will terminate.")
-    exit()
+def main():
+    global plotter, mesh
+    # Auswahl der Mesh-Datei
+    filename = select_mesh_file()
+    if filename:
+        mesh = pv.read(filename)
+    else:
+        print("No file selected. The program will terminate.")
+        exit()
 
-# Einrichten des Plotters
-plotter = pv.Plotter()
-plotter.show_axes()
-add_mesh(mesh)
-plotter.enable_point_picking(callback=on_pick, picker='volume')
+    # Einrichten des Plotters
+    plotter = pv.Plotter()
+    plotter.show_axes()
+    add_mesh(mesh)
+    plotter.enable_point_picking(callback=on_pick, picker='volume')
 
-# Tastenkürzel für die Bestätigung der Achsen
-plotter.add_key_event('x', lambda: confirm_axis_selection(plotter, 'x'))
-plotter.add_key_event('y', lambda: confirm_axis_selection(plotter, 'y'))
-plotter.add_key_event('z', lambda: confirm_axis_selection(plotter, 'z'))
+    # Tastenkürzel für die Bestätigung der Achsen
+    plotter.add_key_event('x', lambda: confirm_axis_selection(plotter, 'x'))
+    plotter.add_key_event('y', lambda: confirm_axis_selection(plotter, 'y'))
+    plotter.add_key_event('z', lambda: confirm_axis_selection(plotter, 'z'))
 
-# Tastenkürzel für andere Funktionen
-plotter.add_key_event('s', save_transformed)
-plotter.add_key_event('r', lambda: reset_selection(plotter))
-plotter.add_key_event('b', lambda: remove_last_picked_point(plotter))
+    # Tastenkürzel für andere Funktionen
+    plotter.add_key_event('s', save_transformed)
+    plotter.add_key_event('r', lambda: reset_selection(plotter))
+    plotter.add_key_event('b', lambda: remove_last_picked_point(plotter))
 
-# Starte die Visualisierung
-plotter.show()
-after_render()
+    # Starte die Visualisierung
+    plotter.show()
+    after_render()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -1,0 +1,67 @@
+import numpy as np
+import importlib
+import os
+import sys
+
+# Ensure the repository root is on the path so that `align` can be imported
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+align = importlib.import_module('align')
+
+class DummyPlotter:
+    def __init__(self):
+        self.cleared = False
+        self.mesh_added = None
+        self.text = ''
+    def clear(self):
+        self.cleared = True
+    def add_mesh(self, mesh, pickable=True, show_edges=True):
+        self.mesh_added = mesh
+    def render(self):
+        pass
+    def add_text(self, text, **kwargs):
+        self.text = text
+
+class DummyMesh:
+    def __init__(self, points):
+        self.points = np.array(points)
+    def copy(self):
+        return DummyMesh(self.points.copy())
+    def save(self, *a, **kw):
+        pass
+
+def setup_module(module):
+    align.plotter = DummyPlotter()
+    align.mesh = DummyMesh([[0,0,0],[1,0,0],[0,1,0]])
+    align.mesh_transformed = None
+    align.picked_points = []
+    align.plane_points = {'first': [], 'second': []}
+    align.axes_confirmed = {'first': None, 'second': None}
+    align.current_axis_selection = 'first'
+
+
+def test_reset_selection():
+    align.picked_points = [[1,2,3]]
+    align.plane_points = {'first': [[0,0,0]], 'second': [[1,1,1]]}
+    align.axes_confirmed = {'first': 'x', 'second': 'y'}
+    align.current_axis_selection = 'second'
+    align.mesh_transformed = DummyMesh([[0,0,0]])
+    align.reset_selection(align.plotter)
+    assert align.picked_points == []
+    assert align.plane_points == {'first': [], 'second': []}
+    assert align.axes_confirmed == {'first': None, 'second': None}
+    assert align.current_axis_selection == 'first'
+
+
+def test_align_and_transform_list_handling():
+    align.mesh = DummyMesh([[0,0,0],[1,0,0],[0,1,0]])
+    align.mesh_transformed = None
+    align.plane_points = {
+        'first': [[0,0,0],[0,1,0],[0,0,1]],
+        'second': [[0,0,0],[1,0,0],[0,1,0]],
+    }
+    align.axes_confirmed = {'first': 'x', 'second': 'z'}
+    align.align_and_transform(align.plotter)
+    assert align.plane_points == {'first': [], 'second': []}
+    assert align.axes_confirmed == {'first': None, 'second': None}
+    assert isinstance(align.mesh_transformed.points, np.ndarray)
+


### PR DESCRIPTION
## Summary
- rename `secound_align_repeatments` to `second_align_repetitions`
- convert `plane_points['second']` to `numpy` array in `align_and_transform`
- wrap executable code in a `main` function
- document `r` and `b` shortcuts in README
- add tests for `reset_selection` and list handling in `align_and_transform`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487ca18bf48332af04c252685c2981